### PR TITLE
Update inetbox.py - change log level

### DIFF
--- a/inetbox/inetbox.py
+++ b/inetbox/inetbox.py
@@ -87,7 +87,7 @@ class InetboxLINProtocol:
                 self.transportlayer_received_request_payload = None
         else:
             sid = f"{sid:x}" if isinstance(sid, int) else sid
-            self.log.warning(f"No idea how to answer this message: frame_type={frame_type} sid={sid} payload={payload}")
+            self.log.debug(f"No idea how to answer this message: frame_type={frame_type} sid={sid} payload={payload}")
             pass
 
     def _complete_transportlayer_request(self, lin: Lin, sid, request_payload):


### PR DESCRIPTION
The following log warnings are spamming my log file. I don't know that this log messages should tell me nor how to resolve this warnings. Hence, I've changed the log level for those messages to `debug`.

```
2025-12-11 18:21:15,709  inet.protocol  WARNING 	No idea how to answer this message: frame_type=single sid=b2 payload=b'#\x17F@\x03'
2025-12-11 18:21:16,545  inet.protocol  WARNING 	No idea how to answer this message: frame_type=single sid=b2 payload=b'\x00\x17F@\x03'
2025-12-11 18:21:16,963  inet.protocol  WARNING 	No idea how to answer this message: frame_type=single sid=b2 payload=b'#\x17F@\x03'
2025-12-11 18:21:17,799  inet.protocol  WARNING 	No idea how to answer this message: frame_type=single sid=b2 payload=b'\x00\x17F@\x03'
2025-12-11 18:21:18,217  inet.protocol  WARNING 	No idea how to answer this message: frame_type=single sid=b2 payload=b'#\x17F@\x03'
2
```
