### PR TITLE
add option to enable MQTT optimistic mode for HA discovery if enabled in service_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The following service-specific settings can be used in the `miqro.yml` file besi
 - `debug_app` (default: False) - Enable debugging for the application layer.
 - `debug_lin` (default: False) - Enable debugging for the LIN layer.
 - `debug_protocol` (default: False) - Enable debugging for the protocol layer.
+- `ha_optimistic` (default: False) - Enables MQTT optimistic mode for Home Assistant entities via auto discovery. When enabled, commands are assumed successful even if no confirmation is received from the device.
 
 ### Installing the Systemd Service
 

--- a/inetbox/truma_service.py
+++ b/inetbox/truma_service.py
@@ -37,7 +37,7 @@ class TrumaService(miqro.Service):
         self.lang = self.service_config.get("language", "none")
 
         # enable MQTT optimistic mode if enabled in service_config
-        self.optimistic = self.service_config.get("optimistic", False)
+        self.optimistic = self.service_config.get("ha_optimistic", False)
 
         self.create_ha_sensors()
 


### PR DESCRIPTION
The Truma heater is unfortunately sometimes not very responsive, and it can take a while for updates to be applied. In certain cases, it may be helpful to enable optimistic mode for the MQTT entities.

This change adds an option to enable optimistic mode via `service_config`. The default is set to `false`.